### PR TITLE
Bugfix file-manager Apple silicon platform support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 .first_run
 vocabulary-db/vocabulary
+.vscode/launch.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **.iml
 .idea
 .first_run
+vocabulary-db/vocabulary

--- a/CONTAINERS.md
+++ b/CONTAINERS.md
@@ -22,7 +22,7 @@
 
     cd perseus-api
     docker build -t backend .
-    docker run --name backend -d -p 5000:5000 -e PERSEUS_ENV='Docker' --network=perseus-net backend
+    docker run --name backend -d -p 5004:5004 -e PERSEUS_ENV='Docker' --network=perseus-net backend
 
 ### User (SMTP server auth)
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,6 +35,7 @@ services:
     depends_on:
       - shareddb
   backend:
+    platform: linux/amd64
     build: ./perseus-api
     container_name: backend
     environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,6 @@
 services:
   web:
+    platform: linux/amd64
     build: ./nginx
     container_name:
       web
@@ -7,6 +8,7 @@ services:
       - "80:80"
     restart: always
   shareddb:
+    platform: linux/amd64
     build: ./shared-db
     container_name: shareddb
     volumes:
@@ -24,6 +26,7 @@ services:
     depends_on:
       - shareddb
   user:
+    platform: linux/amd64
     build: ./user
     container_name: user
     environment:
@@ -46,6 +49,7 @@ services:
       - shareddb
       - files-manager
   frontend:
+    platform: linux/amd64
     build:
       context: ./UI
       args:
@@ -55,6 +59,7 @@ services:
     ports:
       - "4200:4200"
   white-rabbit:
+    platform: linux/amd64
     build: ../WhiteRabbit
     container_name:
       white-rabbit
@@ -66,6 +71,7 @@ services:
       - shareddb
       - files-manager
   vocabularydb:
+    platform: linux/amd64
     build: ./vocabulary-db
     container_name: vocabularydb
     healthcheck:
@@ -78,6 +84,7 @@ services:
     ports:
       - "5431:5432"
   cdm-builder:
+    platform: linux/amd64
     build: ../ETL-CDMBuilder
     container_name:
       cdm-builder
@@ -90,6 +97,7 @@ services:
       - files-manager
       - vocabularydb
   solr:
+    platform: linux/amd64
     build: ./solr
     container_name: solr
     ports:
@@ -99,6 +107,7 @@ services:
     depends_on:
       - vocabularydb
   athena:
+    platform: linux/amd64
     build: ./athena-api
     container_name: athena
     environment:
@@ -108,6 +117,7 @@ services:
     depends_on:
       - solr
   usagi:
+    platform: linux/amd64
     build: ./usagi-api
     command: python /app/main.py
     container_name: usagi
@@ -119,6 +129,7 @@ services:
       - shareddb
       - solr
   r-serve:
+    platform: linux/amd64
     build:
       context: ../DataQualityDashboard/R
       args:
@@ -130,6 +141,7 @@ services:
     depends_on:
       - shareddb
   data-quality-dashboard:
+    platform: linux/amd64
     build:
       context: ../DataQualityDashboard
     container_name:
@@ -143,6 +155,7 @@ services:
       - files-manager
       - r-serve
   swagger:
+    platform: linux/amd64
     build: ./swagger-ui
     ports:
       - 8080:8080

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,7 +41,7 @@ services:
     environment:
       PERSEUS_ENV: Docker
     ports:
-      - "5000:5000"
+      - "5004:5004"
     depends_on:
       - shareddb
       - files-manager

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,7 @@ services:
     ports:
       - "5432:5432"
   files-manager:
+    platform: linux/amd64
     build: ./files-manager
     container_name: files-manager
     ports:

--- a/nginx/server.docker.conf
+++ b/nginx/server.docker.conf
@@ -19,7 +19,7 @@ server {
 		proxy_set_header            X-Forwarded-For $proxy_add_x_forwarded_for;
 		proxy_set_header            X-Forwarded-Proto $scheme;
 		proxy_set_header            Host $host;
-		proxy_pass                  http://172.17.0.1:5000;
+		proxy_pass                  http://172.17.0.1:5004;
 	}
 
     location /user {

--- a/perseus-api/Dockerfile
+++ b/perseus-api/Dockerfile
@@ -15,6 +15,6 @@ COPY sshd_config /etc/ssh/
 COPY entrypoint.sh entrypoint.sh
 RUN chmod +x entrypoint.sh
 
-EXPOSE 5000 2222
+EXPOSE 5004 2222
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/perseus-api/config.py
+++ b/perseus-api/config.py
@@ -1,4 +1,4 @@
-PORT = 5000
+PORT = 5004
 APP_PREFIX = '/backend'
 VERSION = 0.4
 


### PR DESCRIPTION
fix for #19 

```
=> ERROR [internal] load metadata for docker.io/library/openjdk:17-alpine                                                                 0.2s
------
 > [internal] load metadata for docker.io/library/openjdk:17-alpine:
------
failed to solve with frontend dockerfile.v0: failed to create LLB definition: no match for platform in manifest sha256:4b6abae565492dbe9e7a894137c966a7485154238902f2f25e9dbd9784383d81: not found
ERROR: Service 'files-manager' failed to build : Build failed
```

Also, if it's not too much for one PR, I added the vocabulary to the .gitignore.