### PR TITLE
Added Broadsea to angular app and environment file

### DIFF
--- a/UI/angular.json
+++ b/UI/angular.json
@@ -105,6 +105,32 @@
                 }
               ]
             },
+            "broadsea": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.broadsea.ts"
+                }
+              ],
+              "optimization": true,
+              "outputHashing": "all",
+              "sourceMap": false,
+              "namedChunks": false,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": true,
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "2mb",
+                  "maximumError": "5mb"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "6kb"
+                }
+              ]
+            },
             "azure": {
               "fileReplacements": [
                 {

--- a/UI/package.json
+++ b/UI/package.json
@@ -6,6 +6,7 @@
     "start": "ng serve",
     "build": "ng build",
     "build:prod": "ng build --configuration production",
+    "build:broadsea": "ng build --base-href=/perseus/ --configuration broadsea",
     "build:azure": "ng build --configuration azure",
     "build:stats": "ng build --stats-json --configuration production",
     "analyze": "webpack-bundle-analyzer dist/stats.json",

--- a/UI/src/environments/environment.broadsea.ts
+++ b/UI/src/environments/environment.broadsea.ts
@@ -1,0 +1,9 @@
+import { CONCEPT_TABLES } from './concept-tables'
+import { AuthStrategies } from './auth-strategies'
+
+export const environment = {
+  production: true,
+  serverUrl: "/perseus",
+  conceptTables: CONCEPT_TABLES,
+  authStrategy: AuthStrategies.SMTP
+};


### PR DESCRIPTION
In support of #50 , this PR adds a Broadsea build pattern that allows for our traefik proxy (with a route of "/perseus"). The angular build now adds this route as the base href. The broadsea environment TS file points the serverUrl to this route as well.

The idea is that in Broadsea, we can leverage the frontend image by passing env = "broadsea" in our compose profile of the perseus frontend. 

It is possible to set up an environment variable approach, but I didn't want to significantly alter any Perseus code files.